### PR TITLE
Fix GitHub url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Github action of image for building Android apps with support for multiple SDK Build Tools. This Docker image contains the Android SDK and most common packages necessary for building Android apps in a CI tool. 
 
-More details [code0987/android-ci](https://github.com/code09887/android-ci).
+More details [code0987/android-ci](https://github.com/code0987/android-ci).
 
 ### Usage and example
 


### PR DESCRIPTION
The url for the github project was navigating to an existing page, given error 404.

![image](https://user-images.githubusercontent.com/38510547/85065575-cc9e9b00-b183-11ea-89ba-88c70dd81a62.png)
